### PR TITLE
Fix org types, add useCurrentOrgRole hook and accept invite API

### DIFF
--- a/frontend/src/app/(auth)/invite/[token]/page.tsx
+++ b/frontend/src/app/(auth)/invite/[token]/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { use } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuthStore } from '@/store/auth.store';
+import { useAcceptInvite } from '@/features/organizations/hooks/useOrganizations';
+import { ApiError } from '@/types';
+
+function getInviteErrorMessage(error: Error): string {
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case 'INVITE_NOT_FOUND':
+        return 'This invite link is invalid.';
+      case 'INVITE_EXPIRED':
+        return 'This invite has expired. Ask the admin to send a new one.';
+      case 'INVITE_ALREADY_USED':
+        return 'This invite has already been used.';
+      case 'ALREADY_MEMBER':
+        return 'You are already a member of this organization.';
+    }
+  }
+  return 'Failed to accept invite. Please try again.';
+}
+
+export default function AcceptInvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = use(params);
+  const router = useRouter();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const acceptInvite = useAcceptInvite();
+
+  async function handleAccept() {
+    await acceptInvite.mutateAsync(token);
+    router.push('/organizations');
+  }
+
+  // Not authenticated — prompt to sign in
+  if (!accessToken) {
+    const redirectUrl = `/invite/${token}`;
+    return (
+      <div className="rounded-lg bg-white p-8 shadow text-center">
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">You&apos;ve been invited</h1>
+        <p className="mb-6 text-sm text-gray-600">
+          Sign in to accept this invitation and join the organization.
+        </p>
+        <Link
+          href={`/login?redirect=${encodeURIComponent(redirectUrl)}`}
+          className="inline-block rounded bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Sign in
+        </Link>
+        <p className="mt-3 text-xs text-gray-500">
+          Don&apos;t have an account?{' '}
+          <Link
+            href={`/register?redirect=${encodeURIComponent(redirectUrl)}`}
+            className="text-blue-600 hover:underline"
+          >
+            Register
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  // Authenticated — show accept button
+  return (
+    <div className="rounded-lg bg-white p-8 shadow text-center">
+      <h1 className="mb-4 text-2xl font-bold text-gray-900">Accept Invitation</h1>
+
+      {acceptInvite.error && (
+        <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-700">
+          {getInviteErrorMessage(acceptInvite.error)}
+        </div>
+      )}
+
+      {acceptInvite.isSuccess ? (
+        <div>
+          <p className="mb-4 text-sm text-green-700">Invitation accepted successfully!</p>
+          <Link
+            href="/organizations"
+            className="text-sm font-medium text-blue-600 hover:underline"
+          >
+            Go to organizations
+          </Link>
+        </div>
+      ) : (
+        <>
+          <p className="mb-6 text-sm text-gray-600">
+            Click below to join the organization.
+          </p>
+          <button
+            onClick={handleAccept}
+            disabled={acceptInvite.isPending}
+            className="rounded bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {acceptInvite.isPending ? 'Accepting...' : 'Accept Invite'}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useLogin } from '@/features/auth/hooks/useAuth';
 import { ApiError } from '@/types';
 
@@ -22,10 +23,12 @@ function getAuthErrorMessage(error: Error): string {
 }
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') ?? undefined;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
-  const login = useLogin();
+  const login = useLogin(redirect);
 
   function validate(): boolean {
     const next: { email?: string; password?: string } = {};

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useRegister } from '@/features/auth/hooks/useAuth';
 import { ApiError } from '@/types';
 
@@ -29,12 +30,14 @@ interface FormErrors {
 }
 
 export default function RegisterPage() {
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') ?? undefined;
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<FormErrors>({});
-  const register = useRegister();
+  const register = useRegister(redirect);
 
   function validate(): boolean {
     const next: FormErrors = {};

--- a/frontend/src/app/(dashboard)/organizations/page.tsx
+++ b/frontend/src/app/(dashboard)/organizations/page.tsx
@@ -5,31 +5,40 @@ import {
   useOrganizations,
   useCurrentOrganization,
   useSwitchOrganization,
-  useCreateOrganization,
+  useOrgMembers,
+  useCurrentOrgRole,
 } from '@/features/organizations/hooks/useOrganizations';
+import { CreateOrgModal } from '@/features/organizations/components/create-org-modal';
+import { InviteMemberModal } from '@/features/organizations/components/invite-member-modal';
+import { Role } from '@/types';
 import { formatRelative } from '@/lib/utils';
 
 export default function OrganizationsPage() {
   const { data: orgs, isLoading } = useOrganizations();
   const { data: currentOrg } = useCurrentOrganization();
+  const { data: members } = useOrgMembers();
   const switchOrg = useSwitchOrganization();
-  const createOrg = useCreateOrganization();
+  const currentRole = useCurrentOrgRole();
 
-  const [newOrgName, setNewOrgName] = useState('');
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showInviteModal, setShowInviteModal] = useState(false);
 
-  function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-    const name = newOrgName.trim();
-    if (!name) return;
-    createOrg.mutate({ name }, {
-      onSuccess: () => setNewOrgName(''),
-    });
-  }
+  const isAdmin = currentRole === Role.ADMIN;
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">Organizations</h1>
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Organizations</h1>
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Create Organization
+        </button>
+      </div>
 
+      {/* Org list */}
       {isLoading && (
         <p className="text-sm text-gray-500">Loading organizations...</p>
       )}
@@ -46,7 +55,16 @@ export default function OrganizationsPage() {
                 }`}
               >
                 <div>
-                  <h3 className="text-sm font-semibold text-gray-900">{org.name}</h3>
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-sm font-semibold text-gray-900">{org.name}</h3>
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      org.role === Role.ADMIN
+                        ? 'bg-purple-100 text-purple-700'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}>
+                      {org.role}
+                    </span>
+                  </div>
                   <p className="mt-1 text-xs text-gray-500">
                     {org.slug} &middot; Created {formatRelative(org.createdAt)}
                   </p>
@@ -71,29 +89,76 @@ export default function OrganizationsPage() {
       )}
 
       {orgs?.length === 0 && (
-        <p className="text-sm text-gray-500">No organizations yet.</p>
+        <div className="rounded-lg bg-white p-8 text-center shadow-sm">
+          <p className="text-sm text-gray-500">No organizations yet.</p>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="mt-3 text-sm font-medium text-blue-600 hover:underline"
+          >
+            Create your first organization
+          </button>
+        </div>
       )}
 
-      {/* Create organization */}
-      <div className="mt-8">
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Create Organization</h2>
-        <form onSubmit={handleCreate} className="flex gap-3">
-          <input
-            type="text"
-            value={newOrgName}
-            onChange={(e) => setNewOrgName(e.target.value)}
-            placeholder="Organization name"
-            className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-          <button
-            type="submit"
-            disabled={createOrg.isPending || !newOrgName.trim()}
-            className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-          >
-            {createOrg.isPending ? 'Creating...' : 'Create'}
-          </button>
-        </form>
-      </div>
+      {/* Current org members */}
+      {currentOrg && (
+        <div className="mt-8">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">
+              Members &mdash; {currentOrg.name}
+            </h2>
+            {isAdmin && (
+              <button
+                onClick={() => setShowInviteModal(true)}
+                className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Invite Member
+              </button>
+            )}
+          </div>
+
+          {members && members.length > 0 ? (
+            <div className="rounded-lg bg-white shadow-sm">
+              {members.map((member) => (
+                <div
+                  key={member.id}
+                  className="flex items-center justify-between border-b border-gray-100 px-5 py-4 last:border-0"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">
+                      {member.user
+                        ? `${member.user.firstName} ${member.user.lastName}`
+                        : member.userId}
+                    </p>
+                    {member.user && (
+                      <p className="text-xs text-gray-500">{member.user.email}</p>
+                    )}
+                  </div>
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    member.role === Role.ADMIN
+                      ? 'bg-purple-100 text-purple-700'
+                      : 'bg-gray-100 text-gray-600'
+                  }`}>
+                    {member.role}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">No members found.</p>
+          )}
+        </div>
+      )}
+
+      {/* Modals */}
+      <CreateOrgModal
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+      />
+      <InviteMemberModal
+        isOpen={showInviteModal}
+        onClose={() => setShowInviteModal(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { useAuthStore } from '@/store/auth.store';
-import { useCurrentOrganization, useOrgMembers } from '@/features/organizations/hooks/useOrganizations';
+import { useCurrentOrganization } from '@/features/organizations/hooks/useOrganizations';
 
 export default function SettingsPage() {
   const user = useAuthStore((s) => s.user);
   const { data: org } = useCurrentOrganization();
-  const { data: members } = useOrgMembers();
 
   return (
     <div>
@@ -44,29 +43,6 @@ export default function SettingsPage() {
                 <dd className="font-medium text-gray-900">{org.slug}</dd>
               </div>
             </dl>
-          </section>
-        )}
-
-        {members && members.length > 0 && (
-          <section className="rounded-lg bg-white p-6 shadow-sm">
-            <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Members ({members.length})
-            </h2>
-            <ul className="divide-y divide-gray-100">
-              {members.map((member) => (
-                <li
-                  key={member.id}
-                  className="flex items-center justify-between py-3"
-                >
-                  <span className="text-sm text-gray-900">
-                    {member.userId}
-                  </span>
-                  <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-                    {member.role}
-                  </span>
-                </li>
-              ))}
-            </ul>
           </section>
         )}
       </div>

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -6,7 +6,7 @@ import { authApi, type RegisterPayload, type LoginPayload } from '@/lib/api/auth
 import { useAuthStore } from '@/store/auth.store';
 import { connectSocket, disconnectSocket, joinOrgRoom } from '@/lib/socket';
 
-export function useLogin() {
+export function useLogin(redirectTo?: string) {
   const router = useRouter();
   const setAuth = useAuthStore((s) => s.setAuth);
 
@@ -21,12 +21,12 @@ export function useLogin() {
         socket.on('connect', () => joinOrgRoom(user.currentOrganizationId!));
       }
 
-      router.push('/');
+      router.push(redirectTo || '/');
     },
   });
 }
 
-export function useRegister() {
+export function useRegister(redirectTo?: string) {
   const router = useRouter();
   const setAuth = useAuthStore((s) => s.setAuth);
 
@@ -36,7 +36,7 @@ export function useRegister() {
       const { user, accessToken, refreshToken } = data.data!;
       setAuth(user, accessToken, refreshToken);
       connectSocket(accessToken);
-      router.push('/');
+      router.push(redirectTo || '/');
     },
   });
 }

--- a/frontend/src/features/organizations/components/create-org-modal.tsx
+++ b/frontend/src/features/organizations/components/create-org-modal.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  useCreateOrganization,
+  useSwitchOrganization,
+} from '@/features/organizations/hooks/useOrganizations';
+
+interface CreateOrgModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CreateOrgModal({ isOpen, onClose }: CreateOrgModalProps) {
+  const [name, setName] = useState('');
+  const createOrg = useCreateOrganization();
+  const switchOrg = useSwitchOrganization();
+
+  if (!isOpen) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    const { data } = await createOrg.mutateAsync({ name: trimmed });
+    const newOrg = data.data!;
+    await switchOrg.mutateAsync(newOrg.id);
+    setName('');
+    onClose();
+  }
+
+  const isPending = createOrg.isPending || switchOrg.isPending;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900">Create Organization</h2>
+
+        {createOrg.error && (
+          <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-700">
+            Failed to create organization. Please try again.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="org-name" className="mb-1 block text-sm font-medium text-gray-700">
+              Organization name
+            </label>
+            <input
+              id="org-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Acme Inc"
+              autoFocus
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isPending || !name.trim()}
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {isPending ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/organizations/components/invite-member-modal.tsx
+++ b/frontend/src/features/organizations/components/invite-member-modal.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { useCreateInvite } from '@/features/organizations/hooks/useOrganizations';
+import { Role, ApiError } from '@/types';
+
+interface InviteMemberModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function getInviteErrorMessage(error: Error): string {
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case 'ALREADY_MEMBER':
+        return 'This user is already a member of the organization.';
+      case 'INSUFFICIENT_ROLE':
+        return 'You need admin access to invite members.';
+      case 'PLAN_LIMIT_EXCEEDED':
+        return 'Your plan has reached the member limit.';
+    }
+  }
+  return 'Failed to create invite. Please try again.';
+}
+
+export function InviteMemberModal({ isOpen, onClose }: InviteMemberModalProps) {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<Role>(Role.MEMBER);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const createInvite = useCreateInvite();
+
+  if (!isOpen) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setInviteUrl(null);
+
+    const { data } = await createInvite.mutateAsync({
+      email: email.trim() || undefined,
+      role,
+    });
+
+    const token = data.data!.token;
+    if (typeof window !== 'undefined') {
+      setInviteUrl(`${window.location.origin}/invite/${token}`);
+    }
+  }
+
+  function handleCopy() {
+    if (inviteUrl) {
+      navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  function handleClose() {
+    setEmail('');
+    setRole(Role.MEMBER);
+    setInviteUrl(null);
+    setCopied(false);
+    createInvite.reset();
+    onClose();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={handleClose} />
+      <div className="relative z-10 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900">Invite Member</h2>
+
+        {createInvite.error && (
+          <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-700">
+            {getInviteErrorMessage(createInvite.error)}
+          </div>
+        )}
+
+        {inviteUrl ? (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+              Share this link to invite {email ? <strong>{email}</strong> : 'someone'} to the organization:
+            </p>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                readOnly
+                value={inviteUrl}
+                className="flex-1 rounded border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+              />
+              <button
+                onClick={handleCopy}
+                className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={handleClose}
+                className="rounded px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="invite-email" className="mb-1 block text-sm font-medium text-gray-700">
+                Email (optional)
+              </label>
+              <input
+                id="invite-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="teammate@company.com"
+                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Leave empty to create a generic invite link.
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="invite-role" className="mb-1 block text-sm font-medium text-gray-700">
+                Role
+              </label>
+              <select
+                id="invite-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value as Role)}
+                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                <option value={Role.MEMBER}>Member</option>
+                <option value={Role.ADMIN}>Admin</option>
+              </select>
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={createInvite.isPending}
+                className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {createInvite.isPending ? 'Creating...' : 'Create Invite'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/organizations/hooks/useOrganizations.ts
+++ b/frontend/src/features/organizations/hooks/useOrganizations.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/api/organizations.api';
 import { useAuthStore } from '@/store/auth.store';
 import { leaveOrgRoom, joinOrgRoom } from '@/lib/socket';
+import type { OrganizationWithRole, Membership, Role } from '@/types';
 
 export const orgKeys = {
   all: ['organizations'] as const,
@@ -18,7 +19,7 @@ export const orgKeys = {
 export function useOrganizations() {
   return useQuery({
     queryKey: orgKeys.all,
-    queryFn: () => organizationsApi.list().then((r) => r.data.data!),
+    queryFn: () => organizationsApi.list().then((r) => r.data.data! as OrganizationWithRole[]),
   });
 }
 
@@ -30,10 +31,22 @@ export function useCurrentOrganization() {
 }
 
 export function useOrgMembers() {
+  const currentOrganizationId = useAuthStore((s) => s.currentOrganizationId);
+
   return useQuery({
     queryKey: orgKeys.members,
-    queryFn: () => organizationsApi.getMembers().then((r) => r.data.data!),
+    queryFn: () => organizationsApi.getMembers().then((r) => r.data.data! as Membership[]),
+    enabled: !!currentOrganizationId,
   });
+}
+
+export function useCurrentOrgRole(): Role | null {
+  const currentOrganizationId = useAuthStore((s) => s.currentOrganizationId);
+  const { data: orgs } = useOrganizations();
+
+  if (!orgs || !currentOrganizationId) return null;
+  const current = orgs.find((o) => o.id === currentOrganizationId);
+  return current?.role ?? null;
 }
 
 export function useCreateOrganization() {
@@ -61,7 +74,6 @@ export function useSwitchOrganization() {
       setCurrentOrganization(orgId);
       joinOrgRoom(orgId);
 
-      // Invalidate all org-scoped queries
       queryClient.invalidateQueries({ queryKey: orgKeys.current });
       queryClient.invalidateQueries({ queryKey: orgKeys.members });
       queryClient.invalidateQueries({ queryKey: ['projects'] });
@@ -75,5 +87,21 @@ export function useCreateInvite() {
   return useMutation({
     mutationFn: (payload: CreateInvitePayload) =>
       organizationsApi.createInvite(payload),
+  });
+}
+
+export function useAcceptInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (token: string) => organizationsApi.acceptInvite(token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: orgKeys.all });
+      queryClient.invalidateQueries({ queryKey: orgKeys.current });
+      queryClient.invalidateQueries({ queryKey: orgKeys.members });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['activity'] });
+    },
   });
 }

--- a/frontend/src/lib/api/organizations.api.ts
+++ b/frontend/src/lib/api/organizations.api.ts
@@ -44,4 +44,11 @@ export const organizationsApi = {
       payload,
     ).catch(normalizeError);
   },
+
+  acceptInvite(token: string) {
+    return apiClient.post<ApiResponse<Membership>>(
+      '/invitations/accept',
+      { token },
+    ).catch(normalizeError);
+  },
 };

--- a/frontend/src/types/organization.ts
+++ b/frontend/src/types/organization.ts
@@ -9,11 +9,24 @@ export interface Organization {
   updatedAt: string;
 }
 
+export interface OrganizationWithRole extends Organization {
+  role: Role;
+}
+
+export interface MemberUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+}
+
 export interface Membership {
   id: string;
   userId: string;
   organizationId: string;
   role: Role;
+  user?: MemberUser;
   createdAt: string;
 }
 


### PR DESCRIPTION
Add user details to Membership type (backend already sends them), OrganizationWithRole for typed org list with role. Add useCurrentOrgRole() as single source of truth for role-based UI visibility. Add acceptInvite API method and useAcceptInvite hook with broad cache invalidation. Guard members query with enabled: !!currentOrganizationId.