### PR TITLE
Add real-time layer: reconnect-refetch, targeted updates, notifications

### DIFF
--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -74,3 +74,11 @@ export function IconMenu({ className = 'h-5 w-5' }: IconProps) {
     </svg>
   );
 }
+
+export function IconBell({ className = 'h-5 w-5' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+    </svg>
+  );
+}

--- a/frontend/src/components/layout/topbar/index.tsx
+++ b/frontend/src/components/layout/topbar/index.tsx
@@ -1,25 +1,37 @@
 'use client';
 
 import { useUIStore } from '@/store/ui.store';
+import { useSocketStatus } from '@/hooks/useSocketStatus';
 import { UserMenu } from './user-menu';
+import { NotificationDropdown } from './notification-dropdown';
 import { IconMenu } from '@/components/icons';
 
 export function Topbar() {
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const { connected } = useSocketStatus();
 
   return (
     <header className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white px-6">
-      <button
-        onClick={toggleSidebar}
-        className="rounded-md p-2 text-gray-500 hover:bg-gray-100 md:hidden"
-        aria-label="Toggle sidebar"
-      >
-        <IconMenu />
-      </button>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={toggleSidebar}
+          className="rounded-md p-2 text-gray-500 hover:bg-gray-100 md:hidden"
+          aria-label="Toggle sidebar"
+        >
+          <IconMenu />
+        </button>
 
-      <div className="flex-1" />
+        {!connected && (
+          <span className="text-xs text-amber-600 animate-pulse">
+            Reconnecting...
+          </span>
+        )}
+      </div>
 
-      <UserMenu />
+      <div className="flex items-center gap-2">
+        <NotificationDropdown />
+        <UserMenu />
+      </div>
     </header>
   );
 }

--- a/frontend/src/components/layout/topbar/notification-dropdown.tsx
+++ b/frontend/src/components/layout/topbar/notification-dropdown.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useRef, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useNotificationStore } from '@/store/notification.store';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import { IconBell } from '@/components/icons';
+import { formatRelative } from '@/lib/utils';
+
+const ROUTE_MAP: Record<string, (id: string) => string> = {
+  task: (id) => `/tasks`,
+  project: (id) => `/projects/${id}`,
+  organization: () => '/organizations',
+};
+
+export function NotificationDropdown() {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setIsOpen(false), []);
+  useClickOutside(ref, close);
+  const router = useRouter();
+
+  const { notifications, unreadCount, markAllRead } = useNotificationStore();
+
+  function handleClick(entityType?: string, entityId?: string) {
+    if (entityType && entityId) {
+      const getRoute = ROUTE_MAP[entityType];
+      if (getRoute) {
+        router.push(getRoute(entityId));
+      }
+    }
+    close();
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="relative rounded-md p-2 text-gray-500 hover:bg-gray-100 transition-colors"
+        aria-label="Notifications"
+      >
+        <IconBell />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-2 w-80 rounded-lg border border-gray-200 bg-white shadow-lg">
+          <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <h3 className="text-sm font-semibold text-gray-900">Notifications</h3>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <div className="px-4 py-6 text-center text-sm text-gray-500">
+                No notifications yet
+              </div>
+            ) : (
+              notifications.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => handleClick(n.entityType, n.entityId)}
+                  className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-50 ${
+                    !n.read ? 'bg-blue-50/50' : ''
+                  }`}
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-gray-900">{n.message}</p>
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {formatRelative(n.createdAt)}
+                    </p>
+                  </div>
+                  {!n.read && (
+                    <div className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSocketEvents.ts
+++ b/frontend/src/hooks/useSocketEvents.ts
@@ -1,23 +1,33 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { getSocket } from '@/lib/socket';
 import { SocketEvents } from '@/lib/socket/events';
-import type { RealtimeEvent } from '@/types';
+import { useAuthStore } from '@/store/auth.store';
+import { useNotificationStore } from '@/store/notification.store';
+import type { RealtimeEvent, Task, ApiResponse } from '@/types';
 import { taskKeys } from '@/features/tasks/hooks/useTasks';
 import { projectKeys } from '@/features/projects/hooks/useProjects';
 import { orgKeys } from '@/features/organizations/hooks/useOrganizations';
 
 /**
- * Listens to socket events and invalidates the relevant React Query caches.
- * This is the bridge: socket → cache invalidation → automatic UI update.
+ * Core realtime bridge: socket events → cache updates + notifications.
  *
- * Rule: Socket updates invalidate cache (source of truth reconciliation).
- * Never directly mutate UI state from socket events.
+ * Strategy:
+ * - task.updated: targeted cache merge (instant) + invalidate (safety net)
+ * - task.created/deleted, project/member events: invalidate only
+ * - All events: also invalidate activity cache (activity is a derived view)
+ * - Notifications: created for other users' actions only (skip self via actorId)
+ * - Reconnect: org-scoped refetch to close data gaps
+ *
+ * Optimistic + socket collision safety:
+ * Both optimistic updates and socket events converge on server truth via
+ * invalidateQueries. Event deduplication prevents double processing.
  */
 export function useSocketEvents() {
   const queryClient = useQueryClient();
+  const hasConnectedBefore = useRef(false);
 
   useEffect(() => {
     const socket = getSocket();
@@ -25,26 +35,68 @@ export function useSocketEvents() {
 
     const seenEvents = new Set<string>();
 
+    // --- Reconnect refetch ---
+    function handleConnect() {
+      if (hasConnectedBefore.current) {
+        // Refetch stale data after reconnect — events during gap are lost
+        queryClient.invalidateQueries({ queryKey: taskKeys.all });
+        queryClient.invalidateQueries({ queryKey: projectKeys.all });
+        queryClient.invalidateQueries({ queryKey: orgKeys.members });
+        queryClient.invalidateQueries({ queryKey: ['activity'] });
+      }
+      hasConnectedBefore.current = true;
+    }
+
+    // --- Event handler ---
     function handleEvent(event: RealtimeEvent) {
       // Deduplicate: backend can re-deliver on reconnect
       if (seenEvents.has(event.eventId)) return;
       seenEvents.add(event.eventId);
 
-      // Trim dedup set to prevent memory growth
       if (seenEvents.size > 500) {
         const entries = Array.from(seenEvents);
         entries.slice(0, 250).forEach((id) => seenEvents.delete(id));
       }
 
+      const currentUserId = useAuthStore.getState().user?.id;
+
       switch (event.type) {
-        case SocketEvents.TASK_CREATED:
         case SocketEvents.TASK_UPDATED:
+          // Targeted cache update for instant UI (same as optimistic pattern)
+          if (event.data) {
+            const taskData = event.data as Partial<Task> & { id?: string };
+            const taskId = event.entityId || taskData.id;
+            if (taskId) {
+              queryClient.setQueriesData<ApiResponse<Task[]>>(
+                { queryKey: taskKeys.all },
+                (old) => {
+                  if (!old?.data) return old;
+                  return {
+                    ...old,
+                    data: old.data.map((t) => {
+                      if (t.id !== taskId) return t;
+                      const merged = { ...t, ...taskData };
+                      // Timestamp guard: don't overwrite fresher data
+                      if (taskData.updatedAt && t.updatedAt > taskData.updatedAt) return t;
+                      return merged;
+                    }),
+                  };
+                },
+              );
+            }
+          }
+          // Safety net: refetch from server
+          queryClient.invalidateQueries({ queryKey: taskKeys.all });
+          if (event.entityId) {
+            queryClient.invalidateQueries({ queryKey: taskKeys.detail(event.entityId) });
+          }
+          break;
+
+        case SocketEvents.TASK_CREATED:
         case SocketEvents.TASK_DELETED:
           queryClient.invalidateQueries({ queryKey: taskKeys.all });
           if (event.entityId) {
-            queryClient.invalidateQueries({
-              queryKey: taskKeys.detail(event.entityId),
-            });
+            queryClient.invalidateQueries({ queryKey: taskKeys.detail(event.entityId) });
           }
           break;
 
@@ -53,9 +105,7 @@ export function useSocketEvents() {
         case SocketEvents.PROJECT_DELETED:
           queryClient.invalidateQueries({ queryKey: projectKeys.all });
           if (event.entityId) {
-            queryClient.invalidateQueries({
-              queryKey: projectKeys.detail(event.entityId),
-            });
+            queryClient.invalidateQueries({ queryKey: projectKeys.detail(event.entityId) });
           }
           break;
 
@@ -67,21 +117,71 @@ export function useSocketEvents() {
         case SocketEvents.SUBSCRIPTION_CREATED:
         case SocketEvents.SUBSCRIPTION_UPDATED:
         case SocketEvents.SUBSCRIPTION_CANCELED:
-          // Billing queries can be added when the billing feature is built
           break;
+      }
+
+      // Activity is a derived view of all domain events
+      queryClient.invalidateQueries({ queryKey: ['activity'] });
+
+      // Create notification for other users' actions
+      if (event.actorId && event.actorId !== currentUserId) {
+        const message = getEventMessage(event);
+        if (message) {
+          useNotificationStore.getState().addNotification({
+            id: event.eventId,
+            type: event.type,
+            message,
+            entityId: event.entityId,
+            entityType: getEntityType(event.type),
+            actorId: event.actorId,
+            createdAt: event.timestamp,
+            read: false,
+          });
+        }
       }
     }
 
-    // Subscribe to all realtime event types
+    socket.on('connect', handleConnect);
     const eventTypes = Object.values(SocketEvents);
     eventTypes.forEach((eventType) => {
       socket.on(eventType, handleEvent);
     });
 
     return () => {
+      socket.off('connect', handleConnect);
       eventTypes.forEach((eventType) => {
         socket.off(eventType, handleEvent);
       });
     };
   }, [queryClient]);
+}
+
+function getEntityType(eventType: string): 'task' | 'project' | 'organization' | undefined {
+  if (eventType.startsWith('task.')) return 'task';
+  if (eventType.startsWith('project.')) return 'project';
+  if (eventType.startsWith('member.')) return 'organization';
+  return undefined;
+}
+
+function getEventMessage(event: RealtimeEvent): string | null {
+  switch (event.type) {
+    case SocketEvents.TASK_CREATED:
+      return 'New task created';
+    case SocketEvents.TASK_UPDATED:
+      return 'Task updated';
+    case SocketEvents.TASK_DELETED:
+      return 'Task deleted';
+    case SocketEvents.PROJECT_CREATED:
+      return 'New project created';
+    case SocketEvents.PROJECT_UPDATED:
+      return 'Project updated';
+    case SocketEvents.PROJECT_DELETED:
+      return 'Project deleted';
+    case SocketEvents.MEMBER_JOINED:
+      return 'New member joined';
+    case SocketEvents.MEMBER_INVITED:
+      return 'New member invited';
+    default:
+      return null;
+  }
 }

--- a/frontend/src/hooks/useSocketStatus.ts
+++ b/frontend/src/hooks/useSocketStatus.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getSocket } from '@/lib/socket';
+
+export function useSocketStatus() {
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const socket = getSocket();
+    if (!socket) return;
+
+    setConnected(socket.connected);
+
+    function onConnect() { setConnected(true); }
+    function onDisconnect() { setConnected(false); }
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+    };
+  }, []);
+
+  return { connected };
+}

--- a/frontend/src/store/notification.store.ts
+++ b/frontend/src/store/notification.store.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+
+const MAX_NOTIFICATIONS = 50;
+const DEDUP_WINDOW_MS = 2000;
+
+export interface AppNotification {
+  id: string;
+  type: string;
+  message: string;
+  entityId?: string;
+  entityType?: 'task' | 'project' | 'organization';
+  actorId: string;
+  createdAt: string;
+  read: boolean;
+}
+
+interface NotificationState {
+  notifications: AppNotification[];
+  unreadCount: number;
+  addNotification: (n: AppNotification) => void;
+  markAllRead: () => void;
+  clearNotifications: () => void;
+}
+
+export const useNotificationStore = create<NotificationState>()((set, get) => ({
+  notifications: [],
+  unreadCount: 0,
+
+  addNotification: (n) => {
+    const { notifications } = get();
+
+    // Dedup: same type + entityId within window
+    const isDuplicate = notifications.some(
+      (existing) =>
+        existing.type === n.type &&
+        existing.entityId === n.entityId &&
+        Date.now() - new Date(existing.createdAt).getTime() < DEDUP_WINDOW_MS,
+    );
+    if (isDuplicate) return;
+
+    const updated = [n, ...notifications].slice(0, MAX_NOTIFICATIONS);
+    set({
+      notifications: updated,
+      unreadCount: updated.filter((x) => !x.read).length,
+    });
+  },
+
+  markAllRead: () =>
+    set((state) => ({
+      notifications: state.notifications.map((n) => ({ ...n, read: true })),
+      unreadCount: 0,
+    })),
+
+  clearNotifications: () =>
+    set({ notifications: [], unreadCount: 0 }),
+}));


### PR DESCRIPTION
Reconnect-refetch: invalidate task/project/activity/member caches on socket reconnect to close data gaps from disconnect window.

Targeted cache updates: task.updated events merge inline via setQueriesData with timestamp guard to prevent stale overwrites, then invalidateQueries as safety net.

Notification system: Zustand store with dedup (same type+entityId within 2s) and 50-item cap. Actor filtering skips self-triggered events. Bell icon with unread badge in topbar. Dropdown with entity-type route mapping for click-to-navigate.

Connection state: useSocketStatus hook for "Reconnecting..." indicator in topbar. Ephemeral state via hook, not global store.

Activity: all domain events also invalidate activity cache since activity is a derived view of task/project/member events.